### PR TITLE
Reuse workers

### DIFF
--- a/app/assets/javascripts/architect.coffee.erb
+++ b/app/assets/javascripts/architect.coffee.erb
@@ -13,20 +13,36 @@ spawnWorker = (type) ->
   return new @Architect.WORKERS[type].polyfill unless @Architect.SUPPORT_WORKER
   new Worker(@Architect.WORKERS[type].workerPath)
 
-# Public API
+# Short-lived workers
 @Architect.work = (data, type, callback) ->
-  if typeof type is 'function'
-    callback = type
-    type = undefined
-
-  type = 'proxy' if type is undefined
-
   worker = spawnWorker(type)
   worker.postMessage(data)
-  worker.addEventListener 'message', (e) =>
+  worker.addEventListener 'message', (e) ->
     worker.terminate()
     callback(e.data)
 
 @Architect.proxy = (data, callback) => @Architect.work(data, 'proxy', callback)
 @Architect.ajax  = (url,  callback) => @Architect.work(url,  'ajax',  callback)
 @Architect.jsonp = (url,  callback) => @Architect.work(url,  'jsonp', callback)
+
+# Long-lived workers
+jobs = {}
+@Architect.workOn = (jobName, data, type, callback) ->
+  alreadySpawned = !!jobs[jobName]
+
+  worker = jobs[jobName] ||= spawnWorker(type)
+  worker.postMessage(data)
+
+  return if alreadySpawned
+  worker.addEventListener 'message', (e) ->
+    callback(e.data)
+
+@Architect.endJob = (jobName) ->
+  return unless worker = jobs[jobName]
+
+  worker.terminate()
+  delete jobs[jobName]
+
+@Architect.proxyOn = (jobName, data, callback) => @Architect.workOn(jobName, data, 'proxy', callback)
+@Architect.ajaxOn  = (jobName, url,  callback) => @Architect.workOn(jobName, url,  'ajax',  callback)
+@Architect.jsonpOn = (jobName, url,  callback) => @Architect.workOn(jobName, url,  'jsonp', callback)


### PR DESCRIPTION
Creating workers has high start-up performance cost and aren’t exactly intended to be used in large numbers. They’re meant to be long-lived creatures.

I was thinking about this kind of API for reusable workers:

``` js
Architect.workOn('jobName', 'proxy', data, function(data) {
  // This would create a worker without terminating it (like it does w/ Architect.proxy)
})
```

This would allow to use Architect into a loop without using all of the CPU.

**Side note**: From what I could test (even in production) anything in the range of 1-10 shouldn’t be too hard on the CPU if the workers are immediately terminated.
## Typical use case

``` js
var totalPages, jobName, queryApi

totalPages = 10
jobName = 'getUsers'

queryApi = function(page) {
  Architect.workOn(jobName, 'ajax', 'http://api.foo.com/users?page=' + page, function(data) {
    // [Add DOM elements, do your thing ;)]

    if (page == totalPages) {
      // Manually terminate the 'getUsers' ajax worker
      Architect.endJob(jobName)
      console.log('Done')
    } else {
      // Reuse the same worker
      queryApi(page + 1)
    }
  })
}

queryApi(1)
```

The only drawback is that you would absolutely need to manually terminate the worker when you’re done.

Makes sense? Any feedback/concerns welcome.
