### PR TITLE
Fix `define_method` error

### DIFF
--- a/lib/tasks/task_helpers.rb
+++ b/lib/tasks/task_helpers.rb
@@ -10,7 +10,7 @@ end
   35 => 'magenta',
   36 => 'cyan',
 }.each do |code, color|
-  define_method(color) { |text| colorize(text, code) }
+  Kernel.send(:define_method, color) { |text| colorize(text, code) }
 end
 
 def error(text);   puts red('ERROR: ') + text; end


### PR DESCRIPTION
For some reason, the previous code was throwing this error all over:

```
undefined method `define_method' for main:Object
```

Now it doesn’t anymore.
